### PR TITLE
Add short-deck option and UX tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ interface and an interactive GUI, keeping a CSV history of your sessions.
 - Streamlit GUI with card pickers, real‑time validation and Plotly histogram.
 - Mode selector (Basic/Advanced/Equilibrium). Advanced adds adjustable iterations,
   weighted ranges, multiprocessing and extra charts. Equilibrium runs a simple solver.
+- Toggle between Hold'em and Short‑Deck.
+- Solver accuracy presets (Fast/Balanced/Detailed) controlling iteration count.
+- Editable strict‑mode thresholds and persistent defaults in `~/.gto_defaults.json`.
 
 ## Requirements
 

--- a/defaults.json
+++ b/defaults.json
@@ -1,0 +1,9 @@
+{
+  "instructions": "Edit values and copy to ~/.gto_defaults.json to set defaults",
+  "villains": 2,
+  "range": 0,
+  "game": "Holdem",
+  "accuracy": "Balanced",
+  "strict_raise": 0.65,
+  "strict_check": 0.4
+}


### PR DESCRIPTION
## Summary
- add defaults.json for tunable settings
- implement solver accuracy and game type options
- expose strict mode thresholds interactively
- add short deck handling in simulations
- extend Streamlit UI with new controls and sticky header/footer

## Testing
- `python -m py_compile gto_helper.py app.py`